### PR TITLE
Update Song parsing to use Gson

### DIFF
--- a/desk.gmusic.api/.classpath
+++ b/desk.gmusic.api/.classpath
@@ -12,6 +12,7 @@
 			<attribute name="maven.pomderived" value="true"/>
 		</attributes>
 	</classpathentry>
+	<classpathentry kind="src" path="src/test/resources"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.6">
 		<attributes>
 			<attribute name="maven.pomderived" value="true"/>

--- a/desk.gmusic.api/pom.xml
+++ b/desk.gmusic.api/pom.xml
@@ -37,6 +37,12 @@
 			<version>4.11</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<version>1.9.5</version>
+			<scope>test</scope>
+		</dependency>
 
 	</dependencies>
 	<build>

--- a/desk.gmusic.api/src/test/java/gmusic/api/impl/GoogleMusicAPITest.java
+++ b/desk.gmusic.api/src/test/java/gmusic/api/impl/GoogleMusicAPITest.java
@@ -1,0 +1,152 @@
+package gmusic.api.impl;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.isA;
+import static org.mockito.Mockito.when;
+import gmusic.api.comm.FormBuilder;
+import gmusic.api.comm.JSON;
+import gmusic.api.interfaces.IGoogleHttpClient;
+import gmusic.api.model.Song;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import com.google.common.base.Charsets;
+import com.google.common.collect.Lists;
+import com.google.common.io.Files;
+
+public class GoogleMusicAPITest
+{
+	@Mock
+	private IGoogleHttpClient mockHttpClient;
+
+	@Before
+	public void setUp()
+	{
+		MockitoAnnotations.initMocks(this);
+	}
+
+	@Test
+	public void getSongsReturnsSongs() throws IOException, URISyntaxException
+	{
+		// given
+		int expectedSongListSize = 3;
+
+		String expectedSong1Title = "Song Title 1";
+		String expectedSong1Artist = "Artist 1";
+		String expectedSong1Album = "Album 1";
+		int expectedSong1Year = 2012;
+
+		String expectedSong2Title = "Song Title 2";
+		String expectedSong2Artist = "Artist 2";
+		String expectedSong2Album = "Album 2";
+		int expectedSong2Year = 2011;
+
+		String testData = Files.asCharSource(new File("src/test/resources/loadAllTracksResponse.html"), Charsets.UTF_8).read();
+		when(mockHttpClient.dispatchPost(isA(URI.class), isA(FormBuilder.class))).thenReturn(testData);
+
+		GoogleMusicAPI api = new GoogleMusicAPI(mockHttpClient, new JSON(), new File("."));
+
+		// when
+		Collection<Song> songs = api.getAllSongs();
+
+		// then
+		assertEquals(expectedSongListSize, songs.size());
+
+		List<Song> songList = Lists.newArrayList(songs.iterator());
+
+		Song song1 = songList.get(0);
+		assertEquals(expectedSong1Title, song1.getTitle());
+		assertEquals(expectedSong1Artist, song1.getArtist());
+		assertEquals(expectedSong1Album, song1.getAlbum());
+		assertEquals(expectedSong1Year, song1.getYear());
+
+		Song song2 = songList.get(1);
+		assertEquals(expectedSong2Title, song2.getTitle());
+		assertEquals(expectedSong2Artist, song2.getArtist());
+		assertEquals(expectedSong2Album, song2.getAlbum());
+		assertEquals(expectedSong2Year, song2.getYear());
+	}
+
+	@Test
+	public void getSongsParsesSongWithCommas() throws IOException, URISyntaxException
+	{
+		// given
+		int expectedSongListSize = 3;
+
+		String expectedSong3Title = "Song Title, With Comma";
+		String expectedSong3Artist = "Artist 2";
+		String expectedSong3Album = "Album 2";
+		int expectedSong3Year = 2014;
+
+		String testData = Files.asCharSource(new File("src/test/resources/loadAllTracksResponse.html"), Charsets.UTF_8).read();
+		when(mockHttpClient.dispatchPost(isA(URI.class), isA(FormBuilder.class))).thenReturn(testData);
+
+		GoogleMusicAPI api = new GoogleMusicAPI(mockHttpClient, new JSON(), new File("."));
+
+		// when
+		Collection<Song> songs = api.getAllSongs();
+
+		// then
+		assertEquals(expectedSongListSize, songs.size());
+
+		Song song = Lists.newArrayList(songs.iterator()).get(2);
+		assertEquals(expectedSong3Title, song.getTitle());
+		assertEquals(expectedSong3Artist, song.getArtist());
+		assertEquals(expectedSong3Album, song.getAlbum());
+		assertEquals(expectedSong3Year, song.getYear());
+	}
+
+	@Test
+	public void getSongsParsesResponseWithMultipleJSArrays() throws IOException, URISyntaxException
+	{
+		// given
+		int expectedSongListSize = 6;
+
+		String expectedSong3Title = "Song Title, With Comma";
+		String expectedSong3Artist = "Artist 2";
+		String expectedSong3Album = "Album 2";
+		int expectedSong3Year = 2014;
+
+		String expectedSong5Title = "Song Title 5";
+		String expectedSong5Artist = "Artist 5";
+		String expectedSong5Album = "Album 5";
+		int expectedSong5Year = 2011;
+
+		String testData = Files.asCharSource(new File("src/test/resources/loadAllTracksResponseWithMultipleJSArrays.html"),
+				Charsets.UTF_8).read();
+		when(mockHttpClient.dispatchPost(isA(URI.class), isA(FormBuilder.class))).thenReturn(testData);
+
+		GoogleMusicAPI api = new GoogleMusicAPI(mockHttpClient, new JSON(), new File("."));
+
+		// when
+		Collection<Song> songs = api.getAllSongs();
+
+		// then
+		assertEquals(expectedSongListSize, songs.size());
+
+		List<Song> songList = Lists.newArrayList(songs.iterator());
+
+		Song song3 = songList.get(2);
+		assertEquals(expectedSong3Title, song3.getTitle());
+		assertEquals(expectedSong3Artist, song3.getArtist());
+		assertEquals(expectedSong3Album, song3.getAlbum());
+		assertEquals(expectedSong3Year, song3.getYear());
+
+		Song song5 = songList.get(4);
+		assertEquals(expectedSong5Title, song5.getTitle());
+		assertEquals(expectedSong5Artist, song5.getArtist());
+		assertEquals(expectedSong5Album, song5.getAlbum());
+		assertEquals(expectedSong5Year, song5.getYear());
+	}
+
+}

--- a/desk.gmusic.api/src/test/resources/loadAllTracksResponse.html
+++ b/desk.gmusic.api/src/test/resources/loadAllTracksResponse.html
@@ -1,0 +1,21 @@
+<html><head></head><body>
+<script>window.parent['slat_progress'](0.02);</script>
+<script type='text/javascript'>
+window.parent['slat_process']([[["unique-id-1","Song Title 1","//lh6.googleusercontent.com/album-url","Artist 1","Album 1","Album Artist 1",,,,,"","Genre",,3482000,0,0,0,0,2012,0,,,0,0,1365471211056769,1365472938670374,,,,2,"",,,,64,1365472938664000,,,,[]
+,,,,,,,,,,,,[]
+]
+,["unique-id-2","Song Title 2","//lh6.googleusercontent.com/album-url-2","Artist 2","Album 2","Album Artist 2",,,,,"","Genre",,3591000,0,0,0,0,2011,0,,,0,0,1365471218783588,1365473342943365,,,,2,"",,,"id",40,1365473342936000,"//lh4.googleusercontent.com/song-url-2",,,[]
+,,,,,,,,,,,,[]
+]
+,["unique-id-3","Song Title, With Comma","//lh6.googleusercontent.com/album-url-3","Artist 2","Album 2","Album Artist 2",,,,,"","Genre",,4612000,0,0,0,0,2014,0,,,0,0,1398728306580885,1398728332956589,,,,2,"",,,,40,1398728332932000,,,,[]
+,,,,,,,,,,,,[]
+]
+]
+,1398815387326000]
+);
+window.parent['slat_progress'](1.0);
+</script>
+<script type='text/javascript'>
+  window.parent['slat_dispatch'](false);
+</script>
+</body></html>

--- a/desk.gmusic.api/src/test/resources/loadAllTracksResponseWithMultipleJSArrays.html
+++ b/desk.gmusic.api/src/test/resources/loadAllTracksResponseWithMultipleJSArrays.html
@@ -1,0 +1,36 @@
+<html><head></head><body>
+<script>window.parent['slat_progress'](0.02);</script>
+<script type='text/javascript'>
+window.parent['slat_process']([[["unique-id-1","Song Title 1","//lh6.googleusercontent.com/album-url","Artist 1","Album 1","Album Artist 1",,,,,"","Genre",,3482000,0,0,0,0,2012,0,,,0,0,1365471211056769,1365472938670374,,,,2,"",,,,64,1365472938664000,,,,[]
+,,,,,,,,,,,,[]
+]
+,["unique-id-2","Song Title 2","//lh6.googleusercontent.com/album-url-2","Artist 2","Album 2","Album Artist 2",,,,,"","Genre",,3591000,0,0,0,0,2011,0,,,0,0,1365471218783588,1365473342943365,,,,2,"",,,"id",40,1365473342936000,"//lh4.googleusercontent.com/song-url-2",,,[]
+,,,,,,,,,,,,[]
+]
+,["unique-id-3","Song Title, With Comma","//lh6.googleusercontent.com/album-url-3","Artist 2","Album 2","Album Artist 2",,,,,"","Genre",,4612000,0,0,0,0,2014,0,,,0,0,1398728306580885,1398728332956589,,,,2,"",,,,40,1398728332932000,,,,[]
+,,,,,,,,,,,,[]
+]
+]
+,1398815387326000]
+);
+window.parent['slat_progress'](0.37037037037037035);
+</script>
+<script type='text/javascript'>
+window.parent['slat_process']([[["unique-id-4","Song Title 4","//lh6.googleusercontent.com/album-url-4","Artist 4","Album 4","Album Artist 4",,,,,"","Genre",,3482000,0,0,0,0,2012,0,,,0,0,1365471211056769,1365472938670374,,,,2,"",,,,64,1365472938664000,,,,[]
+,,,,,,,,,,,,[]
+]
+,["unique-id-5","Song Title 5","//lh6.googleusercontent.com/album-url-5","Artist 5","Album 5","Album Artist 5",,,,,"","Genre",,3591000,0,0,0,0,2011,0,,,0,0,1365471218783588,1365473342943365,,,,2,"",,,"id",40,1365473342936000,"//lh4.googleusercontent.com/song-url-5",,,[]
+,,,,,,,,,,,,[]
+]
+,["unique-id-6","Song Title 6","//lh6.googleusercontent.com/album-url-6","Artist 6","Album 6","Album Artist 6",,,,,"","Genre",,3591000,0,0,0,0,2011,0,,,0,0,1365471218783588,1365473342943365,,,,2,"",,,"id",40,1365473342936000,"//lh4.googleusercontent.com/song-url-6",,,[]
+,,,,,,,,,,,,[]
+]
+]
+,1398815387326000]
+);
+window.parent['slat_progress'](1.0);
+</script>
+<script type='text/javascript'>
+  window.parent['slat_dispatch'](false);
+</script>
+</body></html>


### PR DESCRIPTION
Replaced the String.split() parsing with the JSON parsing library Gson.
Also, in the case where multiple <script> elements exist, this implementation
will parse each JSON object correctly.

Before this change, if a comma was present within a string (such as
song title or album), extra tokens would be treated as song elements.
This would cause a Song object to be created with invalid data. The Gson
library parses strings with commas and therefore resolves this issue.

Also before this change, responses with multiple <script> elements were
not parsed correctly. For large Song collections, the response may contain
more than one <script> element, breaking up the Song collection JSON.
The previous implementation would not parse the first Song in the second
<script> element. The JSON is now extracted for each <script> element, so
this no longer occurs.
